### PR TITLE
Bump Jenkins to latest LTS version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /tmp
 # $CATALINA_HOME    is derived from the official Tomcat Dockerfile:
 #                   https://github.com/docker-library/tomcat/blob/df283818c1/8-jre8/Dockerfile
 #
-ENV JENKINS_WAR_URL https://updates.jenkins-ci.org/download/war/1.625.2/jenkins.war
+ENV JENKINS_WAR_URL https://updates.jenkins-ci.org/download/war/1.625.3/jenkins.war
 ENV JENKINS_STAGING /var/jenkins_staging
 ENV JENKINS_HOME /var/jenkins_home
 ENV CATALINA_HOME /usr/local/tomcat

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ quickly with Jenkins on the DCOS.
 ## Included in this repo
 Base packages:
   * [Apache Tomcat][tomcat-home] 8.0.27
-  * [Jenkins][jenkins-home] 1.625.2 (LTS)
+  * [Jenkins][jenkins-home] 1.625.3 (LTS)
 
 Jenkins plugins:
   * [credentials][credentials-plugin] v1.23


### PR DESCRIPTION
This includes a security fix (more details at: https://jenkins-ci.org/changelog-stable).
