### PR TITLE
Change to use ZooKeeper for master resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ ENV JENKINS_STAGING /var/jenkins_staging
 ENV JENKINS_HOME /var/jenkins_home
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH "${CATALINA_HOME}/bin:${PATH}"
+ENV JAVA_HOME "/usr/lib/jvm/java-8-openjdk-amd64"
+
 
 RUN rm -rf "${CATALINA_HOME}/webapps/*"
 RUN mkdir -p $JENKINS_HOME
@@ -36,5 +38,8 @@ COPY conf/tomcat/Catalina/localhost/rewrite.config "${CATALINA_HOME}/conf/Catali
 RUN apt-get update
 RUN apt-get install -y git python zip
 RUN /usr/local/jenkins/bin/plugin_install.sh "${JENKINS_STAGING}/plugins"
+
+# Override the default property for DNS lookup caching
+RUN echo 'networkaddress.cache.ttl=60' >> ${JAVA_HOME}/jre/lib/security/java.security
 
 CMD /usr/local/jenkins/bin/bootstrap.py && catalina.sh run

--- a/conf/jenkins/config.xml
+++ b/conf/jenkins/config.xml
@@ -19,7 +19,7 @@
     <org.jenkinsci.plugins.mesos.MesosCloud plugin="mesos">
       <name>MesosCloud</name>
       <nativeLibraryPath>/opt/mesosphere/lib/libmesos.so</nativeLibraryPath>
-      <master>leader.mesos:5050</master>
+      <master>zk://leader.mesos:2181/mesos</master>
       <description></description>
       <frameworkName>jenkins</frameworkName>
       <slavesUser>root</slavesUser>


### PR DESCRIPTION
This change attempts to ameliorate reports that Jenkins is unable to register with the Mesos master by changing the JVM's DNS caching settings and switching the master URL to use ZooKeeper.

It looks like this is happening when a re-election event happens. Since we're using Mesos DNS to point to the leading master, and the default JVM timeout is infinite - Jenkins will be trying to communicate with a master that does not exist.

Furthermore, it looks like the Jenkins Mesos plugin does not attempt to re-register in the case that it is disconnected from the Mesos master when using HTTP to connect to the master. The ZooKeeper driver implementation on the other hand, does.
