### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0.27-jre8
+FROM tomcat:8.0.30-jre8
 WORKDIR /tmp
 
 # Environment variables used throughout this Dockerfile

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ quickly with Jenkins on the DCOS.
 
 ## Included in this repo
 Base packages:
-  * [Apache Tomcat][tomcat-home] 8.0.27
+  * [Apache Tomcat][tomcat-home] 8.0.30
   * [Jenkins][jenkins-home] 1.625.3 (LTS)
 
 Jenkins plugins:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Jenkins plugins:
   * [git-client][git-client-plugin] v1.19.0
   * [greenballs][greenballs-plugin] v1.14
   * [job-dsl][job-dsl-plugin] v1.38
-  * [mesos][mesos-plugin] v0.8.0
+  * [mesos][mesos-plugin] v0.9.0
   * [monitoring][monitoring-plugin] v1.57.0
   * [parameterized-trigger][parameterized-trigger-plugin] v2.29
   * [rebuild][rebuild-plugin] v1.25

--- a/scripts/plugin_install.sh
+++ b/scripts/plugin_install.sh
@@ -19,7 +19,7 @@ JENKINS_PLUGINS=(
     "git-client/1.19.0"
     "greenballs/1.14"
     "job-dsl/1.38"
-    "mesos/0.8.0"
+    "mesos/0.9.0"
     "monitoring/1.57.0"
     "parameterized-trigger/2.29"
     "rebuild/1.25"


### PR DESCRIPTION
Upgrade the version of Jenkins to the latest stable version, the Jenkins Mesos plugin and the Tomcat base image. 

The new plugin removes the need for users to specify a label for builds.
