### PR TITLE
Bump Jenkins version to latest LTS release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /tmp
 #                   data directory. This cannot be populated before Marathon
 #                   has a chance to create the host-container volume mapping.
 #
-ENV JENKINS_WAR_URL https://updates.jenkins-ci.org/download/war/1.642.1/jenkins.war
+ENV JENKINS_WAR_URL https://updates.jenkins-ci.org/download/war/1.642.2/jenkins.war
 ENV JENKINS_STAGING /var/jenkins_staging
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_FOLDER /usr/share/jenkins/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ up and running quickly with Jenkins on DCOS.
 
 ## Included in this repo
 Base packages:
-  * [Jenkins][jenkins-home] 1.642.1 (LTS)
+  * [Jenkins][jenkins-home] 1.642.2 (LTS)
   * [Nginx][nginx-home] 1.9.9
 
 Jenkins plugins:


### PR DESCRIPTION
Updating Jenkins version to include latest LTS release which includes fixes for a recent security advisory: https://wiki.jenkins-ci.org/display/SECURITY/Security+Advisory+2016-02-24
