### PR TITLE
Add credentials binding plugin for easy binding of credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Jenkins plugins:
   * [ansicolor][ansicolor-plugin] v0.4.2
   * [build-pipeline][build-pipeline-plugin] v1.4.9
   * [credentials][credentials-plugin] v1.24
+  * [credentials-binding][credentials-binding-plugin] v1.6
   * [git][git-plugin] v2.4.1
   * [git-client][git-client-plugin] v1.19.2
   * [greenballs][greenballs-plugin] v1.15
@@ -60,6 +61,7 @@ To release a new version of this package:
 [ansicolor-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin
 [build-pipeline-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Build+Pipeline+Plugin
 [credentials-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
+[credentials-binding-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin
 [getting-started]: http://mesosphere.github.io/jenkins-mesos/docs/
 [git-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
 [git-client-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Git+Client+Plugin

--- a/scripts/plugin_install.sh
+++ b/scripts/plugin_install.sh
@@ -17,6 +17,7 @@ JENKINS_PLUGINS=(
     "ansicolor/0.4.2"
     "build-pipeline-plugin/1.4.9"
     "credentials/1.24"
+    "credentials-binding/1.6"
     "git/2.4.1"
     "git-client/1.19.2"
     "greenballs/1.15"


### PR DESCRIPTION
The credentials binding plugin allows you to use stored credentials in your build steps themselves by binding them to environment variables.
