### PR TITLE
SSL Vars Should Be Absolute Paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN mkdir -p ${JENKINS_FOLDER}/war
 
 COPY target/jenkins-*.war ${JENKINS_FOLDER}/jenkins.war
 COPY scripts/bootstrap.py /usr/local/jenkins/bin/bootstrap.py
+COPY scripts/export-libssl.sh /usr/local/jenkins/bin/export-libssl.sh
 
 COPY conf/jenkins/config.xml "${JENKINS_STAGING}/config.xml"
 COPY conf/jenkins/jenkins.model.JenkinsLocationConfiguration.xml "${JENKINS_STAGING}/jenkins.model.JenkinsLocationConfiguration.xml"
@@ -34,7 +35,8 @@ COPY conf/jenkins/nodeMonitors.xml "${JENKINS_STAGING}/nodeMonitors.xml"
 # Override the default property for DNS lookup caching
 RUN echo 'networkaddress.cache.ttl=60' >> ${JAVA_HOME}/jre/lib/security/java.security
 
-CMD /usr/local/jenkins/bin/bootstrap.py && nginx && \
+CMD . /usr/local/jenkins/bin/export-libssl.sh && \
+	/usr/local/jenkins/bin/bootstrap.py && nginx && \
 java ${JVM_OPTS}                                    \
     -Dhudson.udp=-1                                 \
     -Djava.awt.headless=true                        \

--- a/scripts/export-libssl.sh
+++ b/scripts/export-libssl.sh
@@ -1,0 +1,26 @@
+#!/bin/sh 
+#
+# Older versions of mesos or DC/OS send relative paths
+# for the LIBPROCESS_SSL_ environment variables. This
+# script tries to detect that and prepend the env vars
+# with the MESOS_SANDBOX value. This results in an 
+# absolute path to the needed SSL certificates.
+
+# check if the SSL file exists and if not assume it needs
+# the MESOS_SANDBOX prefix.
+fix_ssl_var()
+{
+	local var_name=\$"$1"
+	local var_val=`eval "expr \"$var_name\""`
+	if [ ! -f $var_val ]; then
+		eval "$1=\"$MESOS_SANDBOX/$var_val\""
+	fi
+}
+
+fix_ssl_var LIBPROCESS_SSL_CA_FILE
+fix_ssl_var LIBPROCESS_SSL_CERT_FILE
+fix_ssl_var LIBPROCESS_SSL_KEY_FILE
+
+# pass on new values
+export LIBPROCESS_SSL_CA_FILE LIBPROCESS_SSL_CERT_FILE LIBPROCESS_SSL_KEY_FILE
+


### PR DESCRIPTION
The passed in SSL paths are relative to the MESOS_SANDBOX for DC/OS 1.8
and below (fix intended for 1.9). This is not the directory where Jenkins
is executed from. This commit adds a script that transforms the relative
to absolute paths and allows Jenkins to start on a strict cluster.