### PR TITLE
Update remote FS root to use sandbox.

### DIFF
--- a/conf/jenkins/config.xml
+++ b/conf/jenkins/config.xml
@@ -36,7 +36,7 @@
           <executorCpus>0.1</executorCpus>
           <maxExecutors>4</maxExecutors>
           <executorMem>128</executorMem>
-          <remoteFSRoot>jenkins</remoteFSRoot>
+          <remoteFSRoot>/mnt/mesos/sandbox</remoteFSRoot>
           <idleTerminationMinutes>3</idleTerminationMinutes>
           <jvmArgs>-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true</jvmArgs>
           <jnlpArgs>-noReconnect</jnlpArgs>


### PR DESCRIPTION
This changes the default remoteFSRoot for our default build agent to use the Mesos sandbox directory. Theoretically this should allow us to use the Mesos disk isolation, if enabled, when these agents run and use the sandbox viewer to see workspace files.