### PR TITLE
Update Dockerfile CMD to include default paths for LD_LIBRARY_PATH.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ RUN /usr/local/bin/install-plugins.sh       \
 # disable first-run wizard
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 
-CMD export LD_LIBRARY_PATH=/libmesos-bundle/lib:/libmesos-bundle/lib/mesos:$LD_LIBRARY_PATH                               \
+CMD export LD_LIBRARY_PATH=/libmesos-bundle/lib:/libmesos-bundle/lib/mesos:$LD_LIBRARY_PATH \
   && export MESOS_NATIVE_JAVA_LIBRARY=$(ls /libmesos-bundle/lib/libmesos-*.so)   \
   && . /usr/local/jenkins/bin/export-libssl.sh       \
   && /usr/local/jenkins/bin/bootstrap.py && nginx    \

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ RUN /usr/local/bin/install-plugins.sh       \
 # disable first-run wizard
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 
-CMD export LD_LIBRARY_PATH=/libmesos-bundle/lib:$LD_LIBRARY_PATH                 \
+CMD export LD_LIBRARY_PATH=/libmesos-bundle/lib:/libmesos-bundle/lib/mesos:$LD_LIBRARY_PATH                               \
   && export MESOS_NATIVE_JAVA_LIBRARY=$(ls /libmesos-bundle/lib/libmesos-*.so)   \
   && . /usr/local/jenkins/bin/export-libssl.sh       \
   && /usr/local/jenkins/bin/bootstrap.py && nginx    \


### PR DESCRIPTION
This solves a bug where the executor's LD_LIBRARY_PATH on DC/OS 1.8.8 would be improperly overwritten by the variable we had set in the marathon.json for Jenkins. This would cause Jenkins to fail to start on operating systems where libssl was not present in the system's PATH (e.g. CentOS but not CoreOS). 

See https://github.com/mesosphere/universe/pull/1041 for why this is no longer necessary. This PR adds the contents of that variable to the Docker CMD.