### PR TITLE
Update nginx.conf for tolerant proxy timeout

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -18,6 +18,19 @@ http {
             proxy_set_header   X-Real-IP        $remote_addr;
             proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
             proxy_max_temp_file_size 0;
+            
+            # Based on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      600;
+            proxy_send_timeout         600;
+            proxy_read_timeout         600;
+            send_timeout               600;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
         }
 
         location ~ ^/(?<url>.*)$ {
@@ -27,6 +40,19 @@ http {
             proxy_set_header   X-Real-IP        $remote_addr;
             proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
             proxy_max_temp_file_size 0;
+
+            # Based on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      600;
+            proxy_send_timeout         600;
+            proxy_read_timeout         600;
+            send_timeout               600;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
         }
 
     }


### PR DESCRIPTION
Updates to improve nginx proxy service reliability when dealing with Jenkins latency from any source (network/storage/etc...).

Based on recommendations here: https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy

Mitigator for https://github.com/mesosphere/dcos-jenkins-service/issues/127 -- but would be best done as DC/OS tunable parameters rather than hardcoded into nginx.conf imho.