### PR TITLE
Upgraded jenkins to 2.89.4 to address security advisories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.89.2
+FROM jenkins/jenkins:2.89.4
 WORKDIR /tmp
 
 # Environment variables used throughout this Dockerfile


### PR DESCRIPTION
There is a security advisory for jenkins-core in version 2.89.2

https://jenkins.io/security/advisory/2018-02-14/