### PR TITLE
adding the ability to add an env var of DCOS_PEM as a 64 encoded secr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN echo 'networkaddress.cache.ttl=60' >> ${JAVA_HOME}/jre/lib/security/java.sec
 COPY scripts/bootstrap.py /usr/local/jenkins/bin/bootstrap.py
 COPY scripts/export-libssl.sh /usr/local/jenkins/bin/export-libssl.sh
 COPY scripts/dcos-account.sh /usr/local/jenkins/bin/dcos-account.sh
+COPY scripts/dcos-pem.sh /usr/local/jenkins/bin/dcos-pem.sh
 RUN mkdir -p "$JENKINS_HOME" "${JENKINS_FOLDER}/war"
 
 # nginx setup
@@ -167,6 +168,7 @@ CMD export LD_LIBRARY_PATH=/libmesos-bundle/lib:/libmesos-bundle/lib/mesos:$LD_L
   && . /usr/local/jenkins/bin/export-libssl.sh       \
   && /usr/local/jenkins/bin/bootstrap.py && nginx    \
   && . /usr/local/jenkins/bin/dcos-account.sh        \
+  && . /usr/local/jenkins/bin/dcos-pem.sh            \
   && java ${JVM_OPTS}                                \
      -Dhudson.model.DirectoryBrowserSupport.CSP="${JENKINS_CSP_OPTS}" \
      -Dhudson.udp=-1                                 \

--- a/scripts/dcos-pem.sh
+++ b/scripts/dcos-pem.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Write DC/OS PEM from ENV variable to file and update environment
+# variables accordingly.
+#
+
+# Check if DCOS_PEM is present in env variables
+# and if so write content to local disk. This will overwrite the env 
+# variable with the file location and import the PEM into the JVM keystore.
+write_pem_file()
+{
+    if [ -n "$DCOS_PEM" ]; then
+        local target_file="$JENKINS_HOME/.dcos_pem_64"
+        printf "%s" "$DCOS_PEM" > $target_file
+        #printf "Found DCOS_PEM environment variable, writing for import to $target_file"
+
+        local decoded_target_file="$JENKINS_HOME/.dcos_pem"
+        /usr/bin/openssl base64 -d -in $target_file -out $decoded_target_file 
+
+        # fix env variable
+        DCOS_PEM="file://$target_file"
+        export DCOS_PEM
+
+        # update the JVM keystore with the PEM
+        ${JAVA_HOME}/bin/keytool -keystore ${JAVA_HOME}/jre/lib/security/cacerts -import -alias dcos -file $decoded_target_file -storepass changeit -noprompt
+    fi
+}
+
+write_pem_file

--- a/tests/scripts/create-pem-secret.sh
+++ b/tests/scripts/create-pem-secret.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ dcos security secrets create -f dcos.pem.64 dev/DCOS-pem
+

--- a/tests/scripts/get-pem.sh
+++ b/tests/scripts/get-pem.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "This sets a cluster up with a PEM as a base64 secret, which goes along with scripts/dcos-pem.sh"
+echo "Getting cert from host (make sure this is ONLY IP / hostname - not http://.. ): $1"
+openssl s_client -showcerts -connect $1:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > ./dcos.pem
+openssl base64 -in dcos.pem -out dcos.pem.64 
+
+

--- a/tests/scripts/marathon.json
+++ b/tests/scripts/marathon.json
@@ -1,0 +1,86 @@
+{
+  "id": "/dev/jenkinsmarathon",
+  "acceptedResourceRoles": [
+    "*"
+  ],
+  "backoffFactor": 1.15,
+  "backoffSeconds": 1,
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        "containerPath": "/var/jenkins_home",
+        "hostPath": "/tmp/jenkins",
+        "mode": "RW"
+      }
+    ],
+    "docker": {
+      "image": "jeremykuhnash/dcos-jenkins-service:3.3.0-2.73.1-3",
+      "forcePullImage": true,
+      "privileged": false,
+      "parameters": []
+    }
+  },
+  "cpus": 2,
+  "disk": 0,
+  "env": {
+    "SSH_KNOWN_HOSTS": "github.com",
+    "JENKINS_CONTEXT": "/service/jenkinsmarathon",
+    "JENKINS_SLAVE_AGENT_PORT": "50000",
+    "JENKINS_AGENT_ROLE": "*",
+    "JVM_OPTS": "-Xms4096m -Xmx4096m",
+    "JENKINS_MESOS_MASTER": "zk://leader.mesos:2181/mesos",
+    "JENKINS_AGENT_USER": "root",
+    "JENKINS_FRAMEWORK_NAME": "jenkinsmarathon",
+    "DCOS_PEM": {
+      "secret": "dcosPEM"
+    }
+  },
+  "healthChecks": null,
+  "instances": 1,
+  "labels": {
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "jenkinsmarathon",
+    "DCOS_SERVICE_NAME": "jenkinsmarathon",
+    "DCOS_PACKAGE_NAME":	"jenkins",
+    "DCOS_SERVICE_SCHEME":	"http",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_VHOST": "nginx.dcos.com",
+    "HAPROXY_0_ENABLED": "true",
+    "HAPROXY_1_VHOST": "jenkins.dcos.com",
+    "HAPROXY_1_ENABLED": "true"
+  },
+  "maxLaunchDelaySeconds": 3600,
+  "mem": 8192,
+  "gpus": 0,
+  "networks": [
+    {
+      "mode": "host"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "name": "nginx",
+      "protocol": "tcp"
+    },
+    {
+      "name": "jenkins",
+      "protocol": "tcp"
+    }
+  ],
+  "requirePorts": false,
+  "upgradeStrategy": {
+    "maximumOverCapacity": 0,
+    "minimumHealthCapacity": 0
+  },
+  "killSelection": "YOUNGEST_FIRST",
+  "unreachableStrategy": null,
+  "fetch": [],
+  "secrets": {
+    "dcosPEM": {
+        "source": "dev/DCOS-pem"
+    }
+  },
+  "constraints": []
+}


### PR DESCRIPTION
adding the ability to add an env var of DCOS_PEM as a 64 encoded secret which will be decoded and added to the JVM keystore. This enables easy integration for the marathon plugin to self signed cert
 endpoints.