### PR TITLE
Upgraded jenkins to 2.107.2 to address security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## v3.5.0-2.107.2 (2018-04-12)
+  * Addresses security bulletin for 2018-04-11
+  * Updates blueocean to version 1.5.0
+  * Updates various plugins
+  * Remove ace-editor & momentjs as they should not be installed directly
+
 ## v3.4.0-2.89.2 (2017-12-14)
   * Upgrades Jenkins to 2.89.2 LTS
   * Updates blueocean to version 1.3.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ RUN /usr/local/bin/install-plugins.sh       \
   maven-plugin:3.1.2             \
   mesos:0.16                     \
   metrics:3.1.2.11               \
-  monitoring:1.70.0              \
+  monitoring:1.72.0              \
   nant:1.4.3                     \
   node-iterator-api:1.5.0        \
   pam-auth:1.3                   \
@@ -127,7 +127,7 @@ RUN /usr/local/bin/install-plugins.sh       \
   pipeline-milestone-step:1.3.1  \
   pipeline-model-api:1.2.8       \
   pipeline-model-definition:1.2.8 \
-  pipeline-model-extensions:1.2.5 \
+  pipeline-model-extensions:1.2.8 \
   pipeline-rest-api:2.10         \
   pipeline-stage-step:2.3        \
   pipeline-stage-view:2.10       \
@@ -147,9 +147,9 @@ RUN /usr/local/bin/install-plugins.sh       \
   variant:1.1                    \
   windows-slaves:1.3.1           \
   workflow-aggregator:2.5        \
-  workflow-api:2.26              \
+  workflow-api:2.27              \
   workflow-basic-steps:2.6       \
-  workflow-cps:2.47              \
+  workflow-cps:2.48              \
   workflow-cps-global-lib:2.9    \
   workflow-durable-task-step:2.19 \
   workflow-job:2.18              \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.89.4
+FROM jenkins/jenkins:2.107.2
 WORKDIR /tmp
 
 # Environment variables used throughout this Dockerfile
@@ -12,7 +12,7 @@ ENV JENKINS_FOLDER /usr/share/jenkins
 # Build Args
 ARG LIBMESOS_DOWNLOAD_URL=https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.8.7-1.0.2-2.tar.gz
 ARG LIBMESOS_DOWNLOAD_SHA256=9757b2e86c975488f68ce325fdf08578669e3c0f1fcccf24545d3bd1bd423a25
-ARG BLUEOCEAN_VERSION=1.3.5
+ARG BLUEOCEAN_VERSION=1.5.0
 ARG JENKINS_STAGING=/usr/share/jenkins/ref/
 
 # Default policy according to https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy
@@ -70,95 +70,93 @@ RUN /usr/local/bin/install-plugins.sh       \
   blueocean-rest:${BLUEOCEAN_VERSION}       \
   blueocean-web:${BLUEOCEAN_VERSION}        \
   blueocean:${BLUEOCEAN_VERSION}            \
-  ant:1.7                        \
-  ace-editor:1.1                 \
+  ant:1.8                        \
   ansicolor:0.5.2                \
   antisamy-markup-formatter:1.5  \
-  artifactory:2.13.1             \
+  artifactory:2.15.1             \
   authentication-tokens:1.3      \
-  azure-credentials:1.3.1        \
-  azure-vm-agents:0.5.0          \
-  branch-api:2.0.16              \
-  build-name-setter:1.6.7        \
+  azure-credentials:1.6.0        \
+  azure-vm-agents:0.7.0          \
+  branch-api:2.0.19              \
+  build-name-setter:1.6.9        \
   build-timeout:1.19             \
-  cloudbees-folder:6.2.1         \
+  cloudbees-folder:6.4           \
   conditional-buildstep:1.3.6    \
-  config-file-provider:2.16.4    \
-  copyartifact:1.39              \
-  cvs:2.13                       \
+  config-file-provider:2.18      \
+  copyartifact:1.39.1            \
+  cvs:2.14                       \
   docker-build-publish:1.3.2     \
-  docker-workflow:1.14           \
-  durable-task:1.17              \
-  ec2:1.38                       \
+  docker-workflow:1.15.1         \
+  durable-task:1.22              \
+  ec2:1.39                       \
   embeddable-build-status:1.9    \
   external-monitor-job:1.7       \
-  ghprb:1.39.0                   \
-  git:3.6.4                      \
-  git-client:2.6.0               \
+  ghprb:1.40.0                   \
+  git:3.8.0                      \
+  git-client:2.7.1               \
   git-server:1.7                 \
-  github:1.28.1                  \
+  github:1.29.0                  \
   github-api:1.90                \
-  github-branch-source:2.3.1     \
+  github-branch-source:2.3.3     \
   github-organization-folder:1.6 \
-  gitlab:1.5.2                   \
+  gitlab-plugin:1.5.5            \
   gradle:1.28                    \
   greenballs:1.15                \
   handlebars:1.1.1               \
   ivy:1.28                       \
-  jackson2-api:2.8.10.1          \
-  job-dsl:1.66                   \
+  jackson2-api:2.8.11.1          \
+  job-dsl:1.68                   \
   jobConfigHistory:2.18          \
   jquery:1.12.4-0                \
-  ldap:1.18                      \
+  ldap:1.20                      \
   mapdb-api:1.0.9.0              \
   marathon:1.6.0                 \
   matrix-auth:2.2                \
-  matrix-project:1.12            \
-  maven-plugin:3.0               \
-  mesos:0.15.0                   \
-  metrics:3.1.2.10               \
-  momentjs:1.1.1                 \
+  matrix-project:1.13            \
+  maven-plugin:3.1.2             \
+  mesos:0.16                     \
+  metrics:3.1.2.11               \
   monitoring:1.70.0              \
   nant:1.4.3                     \
   node-iterator-api:1.5.0        \
   pam-auth:1.3                   \
   parameterized-trigger:2.35.2   \
-  pipeline-build-step:2.6        \
+  pipeline-build-step:2.7        \
   pipeline-github-lib:1.0        \
   pipeline-input-step:2.8        \
   pipeline-milestone-step:1.3.1  \
-  pipeline-model-api:1.2.5       \
-  pipeline-model-definition:1.2.5 \
+  pipeline-model-api:1.2.8       \
+  pipeline-model-definition:1.2.8 \
   pipeline-model-extensions:1.2.5 \
-  pipeline-rest-api:2.9          \
+  pipeline-rest-api:2.10         \
   pipeline-stage-step:2.3        \
-  pipeline-stage-view:2.9        \
+  pipeline-stage-view:2.10       \
   plain-credentials:1.4          \
-  rebuild:1.27                   \
-  role-strategy:2.6.1            \
+  rebuild:1.28                   \
+  role-strategy:2.7.0            \
   run-condition:1.0              \
-  s3:0.10.12                     \
+  s3:0.11.0                      \
   saferestart:0.3                \
-  saml:1.0.4                     \
+  saml:1.0.5                     \
   scm-api:2.2.6                  \
   ssh-agent:1.15                 \
-  ssh-slaves:1.23                \
-  subversion:2.10.1              \
-  timestamper:1.8.8              \
-  translation:1.15               \
+  ssh-slaves:1.26                \
+  subversion:2.10.5              \
+  timestamper:1.8.9              \
+  translation:1.16               \
   variant:1.1                    \
   windows-slaves:1.3.1           \
   workflow-aggregator:2.5        \
-  workflow-api:2.24              \
+  workflow-api:2.26              \
   workflow-basic-steps:2.6       \
-  workflow-cps:2.42              \
+  workflow-cps:2.47              \
   workflow-cps-global-lib:2.9    \
-  workflow-durable-task-step:2.17 \
-  workflow-job:2.16              \
-  workflow-multibranch:2.16      \
+  workflow-durable-task-step:2.19 \
+  workflow-job:2.18              \
+  workflow-multibranch:2.17      \
   workflow-scm-step:2.6          \
   workflow-step-api:2.14         \
-  workflow-support:2.16
+  workflow-support:2.18
 
 # disable first-run wizard
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state

--- a/README.md
+++ b/README.md
@@ -18,98 +18,99 @@ Please report issues and submit feature requests for Jenkins on DC/OS by [creati
 
 ## Included in this repo
 Base packages:
-  * [Jenkins][jenkins-home] 2.89.2 (LTS)
+  * [Jenkins][jenkins-home] 2.107.2 (LTS)
   * [Nginx][nginx-home] 1.10.1
 
 Jenkins plugins:
-  * ant v1.7
-  * ace-editor v1.1
+  * ant v1.8
   * ansicolor v0.5.2
   * antisamy-markup-formatter v1.5
-  * artifactory v2.13.1
+  * artifactory v2.15.1
   * authentication-tokens v1.3
-  * azure-vm-agents v0.5.0
-  * blueocean v1.3.5
-  * branch-api v2.0.16
-  * build-name-setter v1.6.7
+  * azure-credentials v1.6.0
+  * azure-vm-agents v0.7.0
+  * blueocean v1.5.0
+  * branch-api v2.0.19
+  * build-name-setter v1.6.9
   * build-timeout v1.19
-  * cloudbees-folder v6.2.1
+  * cloudbees-folder v6.4
   * conditional-buildstep v1.3.6
   * config-file-provider v2.16.4
-  * copyartifact v1.39
-  * cvs v2.13
+  * copyartifact v1.39.1
+  * cvs v2.14
   * docker-build-publish v1.3.2
-  * docker-workflow v1.14
-  * durable-task v1.17
-  * ec2 v1.38
+  * docker-workflow v1.15.1
+  * durable-task v1.22
+  * ec2 v1.39
   * embeddable-build-status v1.9
   * external-monitor-job v1.7
-  * ghprb v1.39.0
-  * git v3.6.4
-  * git-client v2.6.0
+  * ghprb v1.40.0
+  * git v3.8.0
+  * git-client v2.7.1
   * git-server v1.7
-  * github v1.28.1
+  * github v1.29.0
   * github-api v1.90
-  * github-branch-source v2.3.1
+  * github-branch-source v2.3.3
   * github-organization-folder v1.6
-  * gitlab v1.5.2
+  * gitlab-plugin v1.5.5
   * gradle v1.28
   * greenballs v1.15
   * handlebars v1.1.1
   * ivy v1.28
-  * jackson2-api v2.8.10.1
-  * job-dsl v1.66
+  * jackson2-api v2.8.11.1
+  * job-dsl v1.68
   * jobConfigHistory v2.18
   * jquery v1.12.4-0
-  * ldap v1.18
+  * ldap v1.20
   * mapdb-api v1.0.9.0
   * marathon v1.6.0
   * matrix-auth v2.2
-  * matrix-project v1.12
-  * maven-plugin v3.0
-  * mesos v0.15.0
-  * metrics v3.1.2.10
+  * matrix-project v1.13
+  * maven-plugin v3.1.2
+  * mesos v0.16
+  * metrics v3.1.2.11
   * momentjs v1.1.1
   * monitoring v1.70.0
   * nant v1.4.3
   * node-iterator-api v1.5.0
   * pam-auth v1.3
   * parameterized-trigger v2.35.2
-  * pipeline-build-step v2.6
+  * pipeline-build-step v2.7
   * pipeline-github-lib v1.0
   * pipeline-input-step v2.8
   * pipeline-milestone-step v1.3.1
-  * pipeline-model-definition v1.2.5
+  * pipeline-model-api:1.2.8
+  * pipeline-model-definition v1.2.8
   * pipeline-model-extensions v1.2.5
-  * pipeline-rest-api v2.9
+  * pipeline-rest-api v2.10
   * pipeline-stage-step v2.3
-  * pipeline-stage-view v2.9
+  * pipeline-stage-view v2.10
   * plain-credentials v1.4
-  * rebuild v1.27
-  * role-strategy v2.6.1
+  * rebuild v1.28
+  * role-strategy v2.7.0
   * run-condition v1.0
-  * s3 v0.10.12
+  * s3 v0.11.0
   * saferestart v0.3
-  * saml v1.0.4
+  * saml v1.0.5
   * scm-api v2.2.6
   * ssh-agent v1.15
-  * ssh-slaves v1.23
-  * subversion v2.10.1
-  * timestamper v1.8.8
-  * translation v1.15
+  * ssh-slaves v1.26
+  * subversion v2.10.5
+  * timestamper v1.8.9
+  * translation v1.16
   * variant v1.1
   * windows-slaves v1.3.1
   * workflow-aggregator v2.5
-  * workflow-api v2.24
+  * workflow-api v2.26
   * workflow-basic-steps v2.6
-  * workflow-cps v2.42
+  * workflow-cps v2.47
   * workflow-cps-global-lib v2.9
-  * workflow-durable-task-step v2.17
-  * workflow-job v2.16
-  * workflow-multibranch v2.16
+  * workflow-durable-task-step v2.19
+  * workflow-job v2.17
+  * workflow-multibranch v2.17
   * workflow-scm-step v2.6
   * workflow-step-api v2.14
-  * workflow-support v2.16
+  * workflow-support v2.18
 
 ## Packaging
 Jenkins is available as a package in the [Mesosphere Universe][universe].

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Jenkins plugins:
   * mesos v0.16
   * metrics v3.1.2.11
   * momentjs v1.1.1
-  * monitoring v1.70.0
+  * monitoring v1.72.0
   * nant v1.4.3
   * node-iterator-api v1.5.0
   * pam-auth v1.3
@@ -81,7 +81,7 @@ Jenkins plugins:
   * pipeline-milestone-step v1.3.1
   * pipeline-model-api:1.2.8
   * pipeline-model-definition v1.2.8
-  * pipeline-model-extensions v1.2.5
+  * pipeline-model-extensions v1.2.8
   * pipeline-rest-api v2.10
   * pipeline-stage-step v2.3
   * pipeline-stage-view v2.10
@@ -101,9 +101,9 @@ Jenkins plugins:
   * variant v1.1
   * windows-slaves v1.3.1
   * workflow-aggregator v2.5
-  * workflow-api v2.26
+  * workflow-api v2.27
   * workflow-basic-steps v2.6
-  * workflow-cps v2.47
+  * workflow-cps v2.48
   * workflow-cps-global-lib v2.9
   * workflow-durable-task-step v2.19
   * workflow-job v2.17


### PR DESCRIPTION
v3.5.0-2.107.2 (2018-04-12)
  * [Addresses security bulletin for 2018-04-11](https://jenkins.io/security/advisory/2018-04-11/)
  * Updates blueocean to version [1.5.0](https://github.com/jenkinsci/blueocean-plugin/releases)
  * Updates various plugins
  * Remove [ace-editor](https://plugins.jenkins.io/ace-editor) & [momentjs](https://plugins.jenkins.io/momentjs) as they should not be installed directly

Issues still open
 * [deprecated and unsecure JNLP1/JNLP2/JNLP3/CLI1/CLI2](https://issues.jenkins-ci.org/browse/JENKINS-45841) should be disabled by default
 * [libmesos-bundle](https://github.com/mesosphere/dcos-jenkins-service/blob/master/Dockerfile#L13) should be upgraded from 1.8.7 to 1.11.0
 * Disable Jenkins CLI to work in `-remoting mode` by default