### PR TITLE
Tuneable jobs through pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,28 +1,36 @@
-import os
 import logging
-import sys
+import os
 import pytest
+import sys
 
 log_level = os.getenv('TEST_LOG_LEVEL', 'INFO').upper()
 log_levels = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'EXCEPTION')
 assert log_level in log_levels, \
-    '{} is not a valid log level. Use one of: {}'.format(log_level, ', '.join(log_levels))
+    '{} is not a valid log level. Use one of: {}'.format(log_level,
+                                                         ', '.join(log_levels))
 # write everything to stdout due to the following circumstances:
 # - shakedown uses print() aka stdout
 # - teamcity splits out stdout vs stderr into separate outputs, we'd want them combined
 logging.basicConfig(
-    format='[%(asctime)s|%(name)s|%(levelname)s]: %(message)s',
-    level=log_level,
-    stream=sys.stdout)
+        format='[%(asctime)s|%(name)s|%(levelname)s]: %(message)s',
+        level=log_level,
+        stream=sys.stdout)
 
 
 def pytest_addoption(parser):
+    parser.addoption('--masters', action='store', default=1,
+                     help='Number of Jenkins masters to launch.')
     parser.addoption('--jobs', action='store', default=1,
                      help='Number of test jobs to launch.')
     parser.addoption('--single-use', action='store', default=True,
                      help='Use Mesos Single-Use agents')
     parser.addoption('--xmin', action='store', default=1,
                      help='Run job every X minutes.')
+
+
+@pytest.fixture
+def master_count(request):
+    return request.config.getoption('--masters')
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import sys
+import pytest
 
 log_level = os.getenv('TEST_LOG_LEVEL', 'INFO').upper()
 log_levels = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'EXCEPTION')
@@ -13,3 +14,27 @@ logging.basicConfig(
     format='[%(asctime)s|%(name)s|%(levelname)s]: %(message)s',
     level=log_level,
     stream=sys.stdout)
+
+
+def pytest_addoption(parser):
+    parser.addoption('--jobs', action='store', default=1,
+                     help='Number of test jobs to launch.')
+    parser.addoption('--single-use', action='store', default=True,
+                     help='Use Mesos Single-Use agents')
+    parser.addoption('--xmin', action='store', default=1,
+                     help='Run job every X minutes.')
+
+
+@pytest.fixture
+def job_count(request):
+    return request.config.getoption('--jobs')
+
+
+@pytest.fixture
+def single_use(request):
+    return request.config.getoption('--single-use')
+
+
+@pytest.fixture
+def xmin(request):
+    return request.config.getoption('--xmin')

--- a/conftest.py
+++ b/conftest.py
@@ -24,25 +24,25 @@ def pytest_addoption(parser):
                      help='Number of test jobs to launch.')
     parser.addoption('--single-use', action='store', default=True,
                      help='Use Mesos Single-Use agents')
-    parser.addoption('--xmin', action='store', default=1,
+    parser.addoption('--run-delay', action='store', default=1,
                      help='Run job every X minutes.')
 
 
 @pytest.fixture
-def master_count(request):
-    return request.config.getoption('--masters')
+def master_count(request) -> int:
+    return int(request.config.getoption('--masters'))
 
 
 @pytest.fixture
-def job_count(request):
-    return request.config.getoption('--jobs')
+def job_count(request) -> int:
+    return int(request.config.getoption('--jobs'))
 
 
 @pytest.fixture
-def single_use(request):
+def single_use(request) -> int:
     return request.config.getoption('--single-use')
 
 
 @pytest.fixture
-def xmin(request):
-    return request.config.getoption('--xmin')
+def run_delay(request) -> int:
+    return int(request.config.getoption('--run-delay'))

--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -75,16 +75,19 @@ def create_seed_job(
     return r
 
 
-def delete_all_jobs(service_name):
+def delete_all_jobs(service_name, retry=True):
     """Delete all jobs on a Jenkins instance.
 
     Args:
         service_name: Jenkins instance
+        retry: Retry this request
 
     Returns: HTTP Response
 
     """
-    return jenkins_remote_access.delete_all_jobs(service_name=service_name)
+    return jenkins_remote_access.delete_all_jobs(
+            service_name=service_name,
+            retry=retry)
 
 
 def construct_job_config(cmd, schedule_frequency_in_min, labelString):
@@ -123,16 +126,6 @@ def enable_job(service_name, job_name, timeout_seconds=SHORT_TIMEOUT_SECONDS):
 
 def disable_job(service_name, job_name, timeout_seconds=SHORT_TIMEOUT_SECONDS):
     return _set_buildable(service_name, job_name, False, timeout_seconds)
-
-
-def delete_all_jobs(service_name, timeout_seconds=TIMEOUT_SECONDS):
-    for job in get_jobs(service_name, timeout_seconds=timeout_seconds):
-        delete_job(service_name, job['name'], timeout_seconds=timeout_seconds)
-
-
-def delete_job(service_name, job_name, timeout_seconds=TIMEOUT_SECONDS):
-    path = 'job/{}/doDelete'.format(job_name)
-    return sdk_cmd.service_request('POST', service_name, path, timeout_seconds=timeout_seconds)
 
 
 def _set_buildable(service_name, job_name, buildable, timeout_seconds=SHORT_TIMEOUT_SECONDS):

--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -15,7 +15,13 @@ SHORT_TIMEOUT_SECONDS = 30
 log = logging.getLogger(__name__)
 
 
-def install(service_name, port):
+def install(service_name):
+    """Install a Jenkins instance and set the service name to
+    `service_name`. This does not wait for deployment to finish.
+
+    Args:
+        service_name: Unique service name
+    """
     sdk_install.install(
         'jenkins',
         service_name,
@@ -23,9 +29,6 @@ def install(service_name, port):
         additional_options={
             "service": {
                 "name": service_name
-            },
-            "networking": {
-                "agent-port": port
             }
         },
         wait_for_deployment=False)

--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -75,7 +75,7 @@ def create_seed_job(
     return r
 
 
-def delete_all_job(service_name):
+def delete_all_jobs(service_name):
     """Delete all jobs on a Jenkins instance.
 
     Args:

--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -40,7 +40,7 @@ def create_mesos_slave_node(
     # create the mesos slave node with given label. LABEL SHOULD NOT PRE-EXIST.
     return jenkins_remote_access.add_slave_info(
         labelString,
-        service_name,
+        service_name=service_name,
         **kwargs
     )
 
@@ -73,6 +73,18 @@ def create_seed_job(
     r = http.post(url, headers=headers, data=content)
 
     return r
+
+
+def delete_all_job(service_name):
+    """Delete all jobs on a Jenkins instance.
+
+    Args:
+        service_name: Jenkins instance
+
+    Returns: HTTP Response
+
+    """
+    return jenkins_remote_access.delete_all_jobs(service_name=service_name)
 
 
 def construct_job_config(cmd, schedule_frequency_in_min, labelString):

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -104,7 +104,8 @@ def add_slave_info(
         slaveAttributes="",
         jvmArgs="-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true",
         jnlpArgs="-noReconnect",
-        defaultSlave="false"
+        defaultSlave="false",
+        **kwargs
 ):
     slaveInfo = Template(MESOS_SLAVE_INFO_OBJECT).substitute({
          "labelString": labelString,

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -21,7 +21,7 @@ def containerInfo = new MesosSlaveInfo.ContainerInfo(
                 "DOCKER",
                 "mesosphere/jenkins-dind:0.7.0-ubuntu",
                 true,
-                true,
+                false,
                 false,
                 true,
                 "wrapper.sh",

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -19,8 +19,7 @@ import org.jenkinsci.plugins.mesos.MesosSlaveInfo.URI
 DOCKER_CONTAINER = """
 def containerInfo = new MesosSlaveInfo.ContainerInfo(
                 "DOCKER",
-                "mesosphere/jenkins-dind:0.7.0-ubuntu",
-                true,
+                "mesosphere/jenkins-dind:0.7.0-alpine",
                 true,
                 false,
                 true,

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -143,8 +143,8 @@ def remove_slave_info(labelString, service_name):
     )
 
 
-def delete_all_jobs():
-    return make_post(DELETE_ALL_JOBS)
+def delete_all_jobs(**kwargs):
+    return make_post(DELETE_ALL_JOBS, **kwargs)
 
 
 def make_post(

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -83,6 +83,10 @@ cloud.getSlaveInfos().each {
 }
 """
 
+DELETE_ALL_JOBS = """
+Jenkins.instance.items.each { job -> job.delete() }
+"""
+
 
 def add_slave_info(
         labelString,
@@ -137,6 +141,10 @@ def remove_slave_info(labelString, service_name):
         ),
         service_name
     )
+
+
+def delete_all_jobs():
+    return make_post(DELETE_ALL_JOBS)
 
 
 def make_post(

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -19,7 +19,7 @@ import org.jenkinsci.plugins.mesos.MesosSlaveInfo.URI
 DOCKER_CONTAINER = """
 def containerInfo = new MesosSlaveInfo.ContainerInfo(
                 "DOCKER",
-                "mesosphere/jenkins-dind:0.7.0-alpine",
+                "mesosphere/jenkins-dind:0.7.0-ubuntu",
                 true,
                 false,
                 true,

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -21,6 +21,7 @@ def containerInfo = new MesosSlaveInfo.ContainerInfo(
                 "DOCKER",
                 "mesosphere/jenkins-dind:0.7.0-ubuntu",
                 true,
+                true,
                 false,
                 true,
                 "wrapper.sh",
@@ -128,7 +129,8 @@ def add_slave_info(
         DOCKER_CONTAINER +
         slaveInfo +
         MESOS_SLAVE_INFO_ADD,
-        service_name
+        service_name,
+        **kwargs,
     )
 
 
@@ -149,7 +151,8 @@ def delete_all_jobs(**kwargs):
 
 def make_post(
         post_body,
-        service_name
+        service_name,
+        **kwargs
 ):
     """
     :rtype: requests.Response
@@ -169,4 +172,5 @@ def make_post(
         'scriptText',
         log_args=False,
         data={'script': body},
+        **kwargs,
     )

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -88,6 +88,12 @@ def get_config(app_name, timeout=TIMEOUT_SECONDS):
     return config
 
 
+def filter_apps_by_id(filter_id):
+    return sdk_cmd.cluster_request('GET',
+                                   _api_url('apps/?id={}'.format(filter_id)),
+                                   retry=False)
+
+
 def install_app_from_file(app_name: str, app_def_path: str) -> (bool, str):
     """
     Installs a marathon app using the path to an app definition.

--- a/testing/sdk_marathon.py
+++ b/testing/sdk_marathon.py
@@ -89,6 +89,16 @@ def get_config(app_name, timeout=TIMEOUT_SECONDS):
 
 
 def filter_apps_by_id(filter_id):
+    """Return all Marathon apps with an ID matching `filter_id`.
+
+    "jenkins" will return all Marathon apps that begin with "jenkins".
+
+    Args:
+        filter_id: String to filter Marathon app IDs
+
+    Returns: Marathon response
+
+    """
     return sdk_cmd.cluster_request('GET',
                                    _api_url('apps/?id={}'.format(filter_id)),
                                    retry=False)

--- a/testing/testData/gen-job.xml
+++ b/testing/testData/gen-job.xml
@@ -13,6 +13,12 @@
                     <trim>true</trim>
                 </hudson.model.StringParameterDefinition>
                 <hudson.model.StringParameterDefinition>
+                    <name>AGENT_LABEL</name>
+                    <description>Job runs restricted to this label.</description>
+                    <defaultValue/>
+                    <trim>true</trim>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
                     <name>JOBCOUNT</name>
                     <description>The number of jobs to create and manage.</description>
                     <defaultValue>5</defaultValue>
@@ -38,6 +44,7 @@
         <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.69">
             <scriptText>def singleP = &quot;${SINGLE_USE}&quot; as Integer
                 def jobCount = &quot;${JOBCOUNT}&quot; as Integer
+                def agentLabel = "${AGENT_LABEL}" as String
                 def everyMin = &quot;${EVERY_XMIN}&quot; as Integer
 
                 Random random = new Random()
@@ -46,6 +53,10 @@
                 def jobName = &quot;test-job-${c}&quot;
 
                 def j = job(jobName) {
+                if (agentLabel) {
+                label(agentLabel)
+                }
+
                 triggers {
                 cron(&quot;*/${EVERY_XMIN} * * * *&quot;)
                 }

--- a/testing/testData/gen-job.xml
+++ b/testing/testData/gen-job.xml
@@ -1,0 +1,83 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <hudson.model.ParametersDefinitionProperty>
+            <parameterDefinitions>
+                <hudson.model.StringParameterDefinition>
+                    <name>SINGLE_USE</name>
+                    <description>Percentage of jobs that should be Single Use mesos agent.</description>
+                    <defaultValue>100</defaultValue>
+                    <trim>true</trim>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
+                    <name>JOBCOUNT</name>
+                    <description>The number of jobs to create and manage.</description>
+                    <defaultValue>5</defaultValue>
+                    <trim>true</trim>
+                </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
+                    <name>EVERY_XMIN</name>
+                    <description>Every X minutes run this job.</description>
+                    <defaultValue>5</defaultValue>
+                    <trim>false</trim>
+                </hudson.model.StringParameterDefinition>
+            </parameterDefinitions>
+        </hudson.model.ParametersDefinitionProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.69">
+            <scriptText>def singleP = &quot;${SINGLE_USE}&quot; as Integer
+                def jobCount = &quot;${JOBCOUNT}&quot; as Integer
+                def everyMin = &quot;${EVERY_XMIN}&quot; as Integer
+
+                Random random = new Random()
+
+                (1..jobCount).each { c -&gt;
+                def jobName = &quot;test-job-${c}&quot;
+
+                def j = job(jobName) {
+                triggers {
+                cron(&quot;*/${EVERY_XMIN} * * * *&quot;)
+                }
+
+                wrappers {
+                if (Math.abs(random.nextInt() % 100) + 1 &lt;= singleP) {
+                configure { node -&gt;
+                node / &apos;buildWrappers&apos; / &apos;org.jenkinsci.plugins.mesos.MesosSingleUseSlave&apos;()
+                }
+                }
+                }
+
+                steps {
+                shell(&quot;echo &apos;hello, world&apos;; sleep 30&quot;)
+                }
+                }
+
+                queue(j)
+                }
+            </scriptText>
+            <usingScriptText>true</usingScriptText>
+            <sandbox>false</sandbox>
+            <ignoreExisting>false</ignoreExisting>
+            <ignoreMissingFiles>false</ignoreMissingFiles>
+            <failOnMissingPlugin>false</failOnMissingPlugin>
+            <unstableOnDeprecation>false</unstableOnDeprecation>
+            <removedJobAction>DELETE</removedJobAction>
+            <removedViewAction>DELETE</removedViewAction>
+            <removedConfigFilesAction>DELETE</removedConfigFilesAction>
+            <lookupStrategy>JENKINS_ROOT</lookupStrategy>
+        </javaposse.jobdsl.plugin.ExecuteDslScripts>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+</project>

--- a/tests/scale/test_load.py
+++ b/tests/scale/test_load.py
@@ -12,41 +12,27 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.scale
-def test_100_jobs(job_count, single_use, xmin):
-    sdk_install.install(config.PACKAGE_NAME,
-                        config.SERVICE_NAME,
-                        0,
-                        wait_for_deployment=False)
+def test_scaling_load(master_count,
+                      job_count,
+                      single_use,
+                      xmin):
+    """Launch a load test scenario. This does not verify the results
+    of the test, but does ensure the instances and jobs were created.
 
-    job_name = 'generator-job'
-    agent_label = sdk_utils.random_string()
-    job_rand = sdk_utils.random_string()
-    log.info("su type: {}".format(type(single_use)))
-    single_use_str = '100'
-    if not single_use or (
-            type(single_use) == str and single_use.lower() == 'false'
-    ):
-        single_use_str = '0'
-
-    r = jenkins_remote_access.add_slave_info(agent_label)
-    assert r.status_code == 200, 'Got {} when trying to post MesosSlaveInfo'.format(
-            r.status_code)
-    assert agent_label in r.text, 'Label {} missing from {}'.format(agent_label,
-                                                                    r.text)
-    seed_config_xml = jenkins._get_job_fixture('gen-job.xml')
-    seed_config_str = ElementTree.tostring(
-            seed_config_xml.getroot(),
-            encoding='utf8',
-            method='xml')
-    jenkins.create_seed_job(config.SERVICE_NAME, job_name, seed_config_str)
-
-    log.info("Launching {} jobs every {} minutes with single-use set to: {}."
-             .format(job_count, xmin, single_use))
-    jenkins.run_job(config.SERVICE_NAME,
-                    job_name,
-                    **{'JOBCOUNT':   str(job_count),
-                       'SINGLE_USE': single_use_str,
-                       'EVERY_XMIN': str(xmin)})
+    Args:
+        master_count: Number of Jenkins masters or instances
+        job_count: Number of Jobs on each Jenkins master
+        single_use: Mesos Single-Use Agent on (true) or off (false)
+        xmin: Jobs should run every X minute(s)
+    """
+    masters = [("jenkins{}".format(sdk_utils.random_string()), 50000 + i)
+               for i in range(0, int(master_count))]
+    # launch Jenkins services
+    for jen_conf in masters:
+        jenkins.install(jen_conf[0], jen_conf[1])
+    # now try to launch jobs
+    for jen_conf in masters:
+        launch_jobs(jen_conf[0], job_count, single_use, xmin)
 
 
 @pytest.mark.scalecleanup
@@ -55,3 +41,38 @@ def test_cleanup_scale():
     jenkins_remote_access.delete_all_jobs()
     log.info("Uninstalling {}.".format(config.SERVICE_NAME))
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+def launch_jobs(service_name, job_count, single_use, xmin):
+    """Create configured number of jobs with given config on Jenkins
+    instance identified by `service_name`.
+
+    Args:
+        service_name: Jenkins service name
+        job_count: Number of jobs to create and run
+        single_use: Single Use Mesos agent on (true) or off
+        xmin: A job should run every X minute(s)
+
+    """
+    job_name = 'generator-job'
+    # create a new label here?
+    single_use_str = '100'
+    if not single_use or (
+            type(single_use) == str and single_use.lower() == 'false'
+    ):
+        single_use_str = '0'
+
+    seed_config_xml = jenkins._get_job_fixture('gen-job.xml')
+    seed_config_str = ElementTree.tostring(
+            seed_config_xml.getroot(),
+            encoding='utf8',
+            method='xml')
+    jenkins.create_seed_job(service_name, job_name, seed_config_str)
+    log.info(
+            "Launching {} jobs every {} minutes with single-use set to: {}."
+                .format(job_count, xmin, single_use))
+    jenkins.run_job(service_name,
+                    job_name,
+                    **{'JOBCOUNT':   str(job_count),
+                       'SINGLE_USE': single_use_str,
+                       'EVERY_XMIN': str(xmin)})

--- a/tests/scale/test_load.py
+++ b/tests/scale/test_load.py
@@ -39,8 +39,9 @@ def test_scaling_load(master_count,
 
 @pytest.mark.scalecleanup
 def test_cleanup_scale():
+    # TODO: query Marathon for running Jenkins instances
     log.info("Removing all jobs.")
-    jenkins.delete_all_jobs()
+    jenkins.delete_all_jobs('jenkins')
     log.info("Uninstalling {}.".format(config.SERVICE_NAME))
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 

--- a/tests/scale/test_load.py
+++ b/tests/scale/test_load.py
@@ -1,0 +1,57 @@
+import logging
+from xml.etree import ElementTree
+
+import config
+import jenkins
+import jenkins_remote_access
+import pytest
+import sdk_install
+import sdk_utils
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.scale
+def test_100_jobs(job_count, single_use, xmin):
+    sdk_install.install(config.PACKAGE_NAME,
+                        config.SERVICE_NAME,
+                        0,
+                        wait_for_deployment=False)
+
+    job_name = 'generator-job'
+    agent_label = sdk_utils.random_string()
+    job_rand = sdk_utils.random_string()
+    log.info("su type: {}".format(type(single_use)))
+    single_use_str = '100'
+    if not single_use or (
+            type(single_use) == str and single_use.lower() == 'false'
+    ):
+        single_use_str = '0'
+
+    r = jenkins_remote_access.add_slave_info(agent_label)
+    assert r.status_code == 200, 'Got {} when trying to post MesosSlaveInfo'.format(
+            r.status_code)
+    assert agent_label in r.text, 'Label {} missing from {}'.format(agent_label,
+                                                                    r.text)
+    seed_config_xml = jenkins._get_job_fixture('gen-job.xml')
+    seed_config_str = ElementTree.tostring(
+            seed_config_xml.getroot(),
+            encoding='utf8',
+            method='xml')
+    jenkins.create_seed_job(config.SERVICE_NAME, job_name, seed_config_str)
+
+    log.info("Launching {} jobs every {} minutes with single-use set to: {}."
+             .format(job_count, xmin, single_use))
+    jenkins.run_job(config.SERVICE_NAME,
+                    job_name,
+                    **{'JOBCOUNT':   str(job_count),
+                       'SINGLE_USE': single_use_str,
+                       'EVERY_XMIN': str(xmin)})
+
+
+@pytest.mark.scalecleanup
+def test_cleanup_scale():
+    log.info("Removing all jobs.")
+    jenkins_remote_access.delete_all_jobs()
+    log.info("Uninstalling {}.".format(config.SERVICE_NAME))
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/tests/scale/test_load.py
+++ b/tests/scale/test_load.py
@@ -55,7 +55,11 @@ def launch_jobs(service_name, job_count, single_use, xmin):
 
     """
     job_name = 'generator-job'
-    # create a new label here?
+
+    mesosLabel = "mesos{}".format(sdk_utils.random_string())
+    jenkins_remote_access.add_slave_info(mesosLabel,
+                                         service_name=service_name)
+
     single_use_str = '100'
     if not single_use or (
             type(single_use) == str and single_use.lower() == 'false'
@@ -73,6 +77,7 @@ def launch_jobs(service_name, job_count, single_use, xmin):
                 .format(job_count, xmin, single_use))
     jenkins.run_job(service_name,
                     job_name,
-                    **{'JOBCOUNT':   str(job_count),
-                       'SINGLE_USE': single_use_str,
-                       'EVERY_XMIN': str(xmin)})
+                    **{'JOBCOUNT':    str(job_count),
+                       'AGENT_LABEL': mesosLabel,
+                       'SINGLE_USE':  single_use_str,
+                       'EVERY_XMIN':  str(xmin)})

--- a/tests/scale/test_scale_utils.py
+++ b/tests/scale/test_scale_utils.py
@@ -75,7 +75,7 @@ def test_install_custom_name():
     sdk_install.uninstall(config.PACKAGE_NAME, svc_name)
 
     try:
-        jenkins.install(svc_name, 50001)
+        jenkins.install(svc_name)
         jenkins.create_job(svc_name, test_job_name)
         job = jenkins.get_job(svc_name, test_job_name)
         assert test_job_name == job['name']


### PR DESCRIPTION
Add a new mark (`scale`) that is parameterized to deploy a Jenkins instance and trigger a configurable amount of jobs. A cleanup mark (`scalecleanup`) is also included that deletes all jobs and then removes the Jenkins deployment.

Jobs can be created and run through `PYTEST_ARGS`:

```
$ PYTEST_ARGS="--masters=3 --jobs=10" ./test.sh -m scale jenkins
```

Environments can be cleaned up:

```
$ ./test.sh -m scalecleanup jenkins
```
