### PR TITLE
Use one marathon connection

### DIFF
--- a/tests/acceptance/test_jenkins.py
+++ b/tests/acceptance/test_jenkins.py
@@ -11,7 +11,8 @@ WAIT_TIME_IN_SECS = 300
 def test_install_jenkins():
     """Install the Jenkins package for DC/OS.
     """
-    install_package_and_wait(PACKAGE_NAME)
+    client = shakedown.marathon.create_client()
+    install_package_and_wait(PACKAGE_NAME, client)
     assert package_installed(PACKAGE_NAME), 'Package failed to install'
 
     end_time = time.time() + WAIT_TIME_IN_SECS

--- a/tests/scale/test_scale_utils.py
+++ b/tests/scale/test_scale_utils.py
@@ -8,6 +8,7 @@ import pytest
 import retrying
 import sdk_install
 import sdk_utils
+import shakedown
 
 log = logging.getLogger(__name__)
 
@@ -75,7 +76,8 @@ def test_install_custom_name():
     sdk_install.uninstall(config.PACKAGE_NAME, svc_name)
 
     try:
-        jenkins.install(svc_name)
+        client = shakedown.marathon.create_client()
+        jenkins.install(svc_name, client)
         jenkins.create_job(svc_name, test_job_name)
         job = jenkins.get_job(svc_name, test_job_name)
         assert test_job_name == job['name']


### PR DESCRIPTION
Create one marathon client and use that for all installations. This
is to help against flooding the service and to prevent changing the
`dcos` config numerous times per execution.