### PR TITLE
Add VIP support when using mom

### DIFF
--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -63,7 +63,7 @@ def install(service_name, role=None, mom=None, external_volume=None,
             if 'portDefinitions' in pkg_json:
                 p0 = pkg_json['portDefinitions'][0]
                 p0['labels'] = {
-                    'VIP_0': "{}.{}.l4lb.thisdcos.directory:10000"
+                    'VIP_0': "api.{}.{}.l4lb.thisdcos.directory:10000"
                              .format(service_name, mom)
                 }
 
@@ -82,7 +82,7 @@ def install(service_name, role=None, mom=None, external_volume=None,
 
     if strict_settings:
         if mom:
-            vip = "https://{}.{}.l4lb.thisdcos.directory:10000"\
+            vip = "https://api.{}.{}.l4lb.thisdcos.directory:10000"\
                 .format(service_name, mom)
         else:
             vip = None

--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -60,13 +60,6 @@ def install(service_name, role=None, mom=None, external_volume=None,
         # this will register at `/service/<service_name>`
         pkg_json = sdk_install.get_package_json('jenkins', None, options)
         with marathon_on_marathon(mom):
-            if 'portDefinitions' in pkg_json:
-                p0 = pkg_json['portDefinitions'][0]
-                p0['labels'] = {
-                    'VIP_0': "api.{}.{}.l4lb.thisdcos.directory:10000"
-                             .format(service_name, mom)
-                }
-
             c = marathon.create_client()
             c.add_app(pkg_json)
             time_wait(lambda: deployment_predicate(service_name),

--- a/testing/jenkins_remote_access.py
+++ b/testing/jenkins_remote_access.py
@@ -193,14 +193,15 @@ def add_slave_info(
     )
 
 
-def remove_slave_info(labelString, service_name):
+def remove_slave_info(labelString, service_name, **kwargs):
     return make_post(
         Template(MESOS_SLAVE_INFO_REMOVE).substitute(
             {
                 'labelString': labelString
             }
         ),
-        service_name
+        service_name,
+        **kwargs
     )
 
 
@@ -208,18 +209,19 @@ def delete_all_jobs(**kwargs):
     return make_post(DELETE_ALL_JOBS, **kwargs)
 
 
-def get_job_failures(service_name):
-    return make_post(JENKINS_JOB_FAILURES, service_name)
+def get_job_failures(service_name, **kwargs):
+    return make_post(JENKINS_JOB_FAILURES, service_name, **kwargs)
 
 
-def change_mesos_creds(mesos_username, service_name):
+def change_mesos_creds(mesos_username, service_name, **kwargs):
     return make_post(
         Template(CREDENTIAL_CHANGE).substitute(
             {
                 'userName': mesos_username,
             }
         ),
-        service_name)
+        service_name,
+        **kwargs)
 
 
 def make_post(

--- a/testing/sdk_cmd.py
+++ b/testing/sdk_cmd.py
@@ -52,6 +52,7 @@ def cluster_request(
         log_args=True,
         verify=None,
         timeout_seconds=60,
+        vip=None,
         **kwargs):
     """Queries the provided cluster HTTP path using the provided method, with the following handy features:
     - The DCOS cluster's URL is automatically applied to the provided path.
@@ -69,8 +70,10 @@ def cluster_request(
                    or `params={"example": "param"}`.
     :rtype: requests.Response
     """
-
-    url = shakedown.dcos_url_path(cluster_path)
+    if vip:
+        url = "{}{}".format(vip, cluster_path)
+    else:
+        url = shakedown.dcos_url_path(cluster_path)
     cluster_path = '/' + cluster_path.lstrip('/')  # consistently include slash prefix for clearer logging below
     log.info('(HTTP {}) {}'.format(method.upper(), cluster_path))
 

--- a/tests/scale/test_load.py
+++ b/tests/scale/test_load.py
@@ -279,7 +279,7 @@ def _create_jobs(service_name, **kwargs):
         service_name: Jenkins instance name
     """
     if 'mom' in kwargs:
-        kwargs['vip'] = "https://{}.{}.l4lb.thisdcos.directory:10000"\
+        kwargs['vip'] = "https://api.{}.{}.l4lb.thisdcos.directory:10000"\
             .format(service_name, kwargs['mom'])
     m_label = _create_executor_configuration(service_name, **kwargs)
     _launch_jobs(service_name, label=m_label, **kwargs)


### PR DESCRIPTION
When --mom is set, this will automatically create and use a VIP
for all Jenkins traffic after installation.

This does not change behavior on root marathon.