### PR TITLE
Add init script for mesos auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY conf/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY conf/jenkins/config.xml "${JENKINS_STAGING}/config.xml"
 COPY conf/jenkins/jenkins.model.JenkinsLocationConfiguration.xml "${JENKINS_STAGING}/jenkins.model.JenkinsLocationConfiguration.xml"
 COPY conf/jenkins/nodeMonitors.xml "${JENKINS_STAGING}/nodeMonitors.xml"
+COPY scripts/init.groovy.d/mesos-auth.groovy "${JENKINS_STAGING}/init.groovy.d/mesos-auth.groovy"
 
 # add plugins
 RUN /usr/local/bin/install-plugins.sh       \

--- a/scripts/init.groovy.d/mesos-auth.groovy
+++ b/scripts/init.groovy.d/mesos-auth.groovy
@@ -1,0 +1,51 @@
+import com.cloudbees.plugins.credentials.*
+import com.cloudbees.plugins.credentials.domains.*
+import com.cloudbees.plugins.credentials.impl.*
+import hudson.tasks.*
+import jenkins.model.*
+import org.jenkinsci.plugins.mesos.MesosCloud
+
+def changePassword = { userName ->
+  def cloud = MesosCloud.get()
+  def credentialsId = cloud.getCredentialsId()
+  def credId = "mesos-${userName}"
+
+  if (credentialsId && credentialsId == credId) {
+    // do nothing if credential already exists
+    println "--> [mesos] credentials already selected"
+  } else {
+    // create a new credential with an expected ID
+    println "--> [mesos] creating new credentials"
+    String randomPwd = org.apache.commons.lang.RandomStringUtils.random(9, true, true)
+
+    mesosFrameworkCreds = new UsernamePasswordCredentialsImpl(
+      CredentialsScope.GLOBAL,
+      "mesos-${userName}",
+      "mesos authentication",
+      userName, randomPwd)
+    SystemCredentialsProvider.getInstance().getStore().addCredentials(Domain.global(), mesosFrameworkCreds)
+    cloud.setCredentialsId(mesosFrameworkCreds.getId())
+    Jenkins.getInstance().save()
+    cloud.restartMesos()
+
+    println "--> [mesos] creating new credentials... done"
+  }
+}
+
+def accountCreds = System.getenv("DCOS_SERVICE_ACCOUNT_CREDENTIAL")
+if (accountCreds) {
+  Thread.start {
+    // wait 30s, this gives the mesos plugin time to start
+    sleep 30000
+    def credURL = new URL(accountCreds)
+    def credFile = new File(credURL.toURI())
+    def credJSON = new groovy.json.JsonSlurper().parseText(credFile.text)
+    if (credJSON && credJSON.uid) {
+        changePassword(credJSON.uid)
+    } else {
+      println "--> [mesos] Failed to read principal from credentials file"
+    }
+  }
+} else {
+  println "--> [mesos] No DC/OS account detected; skipping mesos auth"
+}

--- a/scripts/init.groovy.d/mesos-auth.groovy
+++ b/scripts/init.groovy.d/mesos-auth.groovy
@@ -32,6 +32,7 @@ def changePassword = { userName ->
   }
 }
 
+// the env var is set by DCOS when using a service account to run Jenkins
 def accountCreds = System.getenv("DCOS_SERVICE_ACCOUNT_CREDENTIAL")
 if (accountCreds) {
   Thread.start {

--- a/testing/jenkins.py
+++ b/testing/jenkins.py
@@ -73,10 +73,6 @@ def install(service_name, role=None, mom=None, external_volume=None,
             additional_options=options,
             wait_for_deployment=False)
 
-    if strict_settings:
-        jenkins_remote_access.change_mesos_creds(
-            strict_settings['mesos_principal'], service_name)
-
 
 def uninstall(service_name, package_name='jenkins', role=None, mom=None):
     """Uninstall a Jenkins instance. This does not wait for deployment


### PR DESCRIPTION
Use the init hook system of Jenkins to set the correct credentials for the Mesos Cloud when run on a strict DC/OS cluster.