### PR TITLE
Setting 'keepalive' for nginx

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -18,6 +18,7 @@ http {
             proxy_set_header   Host             $http_host;
             proxy_set_header   X-Real-IP        $remote_addr;
             proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
             proxy_max_temp_file_size 0;
             
             # Based on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy
@@ -40,6 +41,7 @@ http {
             proxy_set_header   Host             $http_host;
             proxy_set_header   X-Real-IP        $remote_addr;
             proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
             proxy_max_temp_file_size 0;
 
             # Based on https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy


### PR DESCRIPTION
Research has indicated that this could help reduce '504 timeout'
errors and stress on the system when nginx is functioning as
a revers proxy.  Adding the server directives for keepalive
as noted here:

http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive