### PR TITLE
Configure Admin-Router roles

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,9 @@ def pytest_addoption(parser):
     parser.addoption('--cpu-quota', action='store', default=0.0,
                      type=float, help='CPU quota to set. 0.0 to set no'
                                       ' quota.')
+    parser.addoption('--memory-quota', action='store', default=0.0,
+                     type=float, help='Memory quota to set. 0.0 to set no'
+                                      ' quota.')
     parser.addoption('--work-duration', action='store', default=600,
                      type=int, help='Duration, in seconds, for the '
                                     'workload to last (sleep).')
@@ -75,6 +78,11 @@ def run_delay(request) -> int:
 @pytest.fixture
 def cpu_quota(request) -> float:
     return float(request.config.getoption('--cpu-quota'))
+
+
+@pytest.fixture
+def memory_quota(request) -> float:
+    return float(request.config.getoption('--memory-quota'))
 
 
 @pytest.fixture

--- a/testing/sdk_security.py
+++ b/testing/sdk_security.py
@@ -45,7 +45,7 @@ def install_enterprise_cli(force=False):
         raise RuntimeError("Failed to install the dcos-enterprise-cli: {}".format(repr(e)))
 
 
-def _grant(user: str, acl: str, description: str, action: str="create") -> None:
+def grant(user: str, acl: str, description: str, action: str="create") -> None:
     log.info('Granting permission to {user} for {acl}/{action} ({description})'.format(
         user=user, acl=acl, action=action, description=description))
 
@@ -133,7 +133,7 @@ def grant_permissions(linux_user: str, role_name: str, service_account_name: str
     log.info("Granting permissions to {account}".format(account=service_account_name))
     permissions = get_permissions(service_account_name, role_name, linux_user)
     for permission in permissions:
-        _grant(**permission)
+        grant(**permission)
     log.info("Permission setup completed for {account}".format(account=service_account_name))
 
 


### PR DESCRIPTION
Grant Admin Router access to `mom` and `jenkins-role` mesos roles.

JIRA: [DCOS-52220](https://jira.mesosphere.com/browse/DCOS-52220)